### PR TITLE
Add support for running on macOS

### DIFF
--- a/ttn_mass_provision/app.py
+++ b/ttn_mass_provision/app.py
@@ -240,7 +240,7 @@ class App():
                 raise self.Error(
                     f"can't convert Organization() for organization {options.organization:s}: check settings.json: {e}")
         else:
-            print("not a valid organization: %s", options.organization)
+            print("not a valid organization: %s" % options.organization)
             sys.exit(1)
 
         # now, get the jumphosts

--- a/ttn_mass_provision/app.py
+++ b/ttn_mass_provision/app.py
@@ -23,6 +23,7 @@ import ipaddress
 import jsons
 import logging
 import pathlib
+import re
 import sys
 import time
 import typing
@@ -292,6 +293,7 @@ class App():
     ##################################################
     # Find all the MultiTech gateways on the network #
     ##################################################
+    ARP_RE = re.compile(r'\S+ \((?P<ip>[0-9.]+)\) at (?P<macaddr>0?0:0?8:0?0(:[0-9a-fA-F]?[0-9a-fA-F]){3})\s')
     def find_conduits(self) -> bool:
         options = self.args
         logger = self.logger
@@ -307,28 +309,29 @@ class App():
             logger.error("mass ping failed: %s", error)
             return False
 
-        # grab the arp buffer
+        # grab the arp table
+        cmd = "arp -an"
         try:
-            with open("/proc/net/arp", "r") as f:
-                arplist = f.read().splitlines()[1:]
+            logger.debug("Running %s", cmd)
+            result = invoke.run(cmd, out_stream=stdout)
         except Exception as error:
-            logger.error("arp read failed: %s", error)
+            logger.error("%s failed: %s", cmd, error)
             return False
 
-        # for each line, split and match
         conduits: List[Conduit] = []
-        for line in arplist:
-            fields = line.split()
-            macaddr = fields[3]
-            if macaddr.startswith("00:08:00:"):
-                conduits.append(
-                    Conduit(
-                        ip=ipaddress.IPv4Address(fields[0]),
-                        mac=macaddr.replace(':', '-'),
-                        options=options,
-                        settings=self.settings
-                        )
-                    )
+        for line in result.stdout.split('\n'):
+            match = ARP_RE.match(line)
+            if not match:
+                continue
+            macaddr = '-'.join(["%02x" % int(hex, 16) for hex in match.group('macaddr').split(':')])
+            conduits.append(
+                Conduit(
+                    ip=ipaddress.IPv4Address(match.group('ip')),
+                    mac=macaddr,
+                    options=options,
+                    settings=self.settings
+                )
+            )
         self.conduits = conduits
         self.conduits.sort(key=lambda conduit: conduit.mac)
         return True

--- a/ttn_mass_provision/app.py
+++ b/ttn_mass_provision/app.py
@@ -301,7 +301,7 @@ class App():
         stdout = io.StringIO()
 
         hosts = ' '.join([ str(host) for host in options.address.hosts()])
-        cmd = "for i in %s; do { ( ping -c2 -W1 $i |& grep -q '0 received' || echo $i ; ) & disown; } done" % hosts
+        cmd = "for i in %s; do { ( ping -c2 -W1 $i 2>&1 | grep -q '0 received' || echo $i ; ) & disown; } done" % hosts
         try:
             logger.debug("launch command: %s", cmd)
             result = invoke.run(cmd, out_stream=stdout)

--- a/ttn_mass_provision/settings.json
+++ b/ttn_mass_provision/settings.json
@@ -52,6 +52,13 @@
                     "prefix": "ttn-nyc-",
                     "org_dir": "org-ttnnyc-gateways",
                     "jumphosts": [ "jumphost.ttni.tech" ]
+                },
+            "ttn-ithaca":
+                {
+                    "description": "The Things Network Ithaca",
+                    "prefix": "ttn-ithaca-",
+                    "org_dir": "org-ttn-ithaca-gateways",
+                    "jumphosts": [ "jumphost.ttni.tech" ]
                 }
         },
     "jumphosts":

--- a/ttn_mass_provision/settings.json
+++ b/ttn_mass_provision/settings.json
@@ -19,6 +19,12 @@
                     "device_type": "Conduit 210L",
                     "has_cellular": false
                 },
+	    "MTCDT-L4N1-240A":
+                {
+                    "device_class": "Conduit 2",
+                    "device_type": "Conduit 240L",
+                    "has_cellular": true
+                },
             "MTCDT-246L":
                 {
                     "device_class": "Conduit 2",


### PR DESCRIPTION
1. Don't use /proc/net/arp, use output of `arp -an`
2. Fix bash command that pings devices to work with bash 3

Also add support for MTCDT-L4N1-240A and ttn-ithaca org

Addresses #1 